### PR TITLE
Resolve namespace of Categories dynamically

### DIFF
--- a/src/Services/BaseDiscoveryService.php
+++ b/src/Services/BaseDiscoveryService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NodiLabs\NodiShell\Services;
+
+class BaseDiscoveryService
+{
+    function getNamespaceFromFile($filePath)
+    {
+        if (!file_exists($filePath)) {
+            throw new Exception('File not found');
+        }
+
+        $content = file_get_contents($filePath);
+
+        // Regular expression to match the namespace declaration
+        if (preg_match('/namespace\s+([^\s;]+);/m', $content, $matches)) {
+            return $matches[1];
+        } else {
+            throw new Exception('No namespace found in the file');
+        }
+    }
+}

--- a/src/Services/CategoryDiscoveryService.php
+++ b/src/Services/CategoryDiscoveryService.php
@@ -85,7 +85,7 @@ class CategoryDiscoveryService
     public function discover(): void
     {
         $categoryPath = config('nodishell.discovery.categories_path');
-        $baseNamespace = 'App\\Console\\NodiShell\\Categories';
+
 
         if (! file_exists($categoryPath)) {
             // Or log a warning, depending on desired behavior
@@ -100,9 +100,10 @@ class CategoryDiscoveryService
             }
 
             $className = $file->getBasename('.php');
-            $fqcn = $baseNamespace.'\\'.$className;
+            $fqcn = $this->getNamespaceFromFile($categoryPath.DIRECTORY_SEPARATOR.$file->getBasename('.php').'.php').'\\'.$className;
 
             if (class_exists($fqcn)) {
+
                 $reflection = new \ReflectionClass($fqcn);
 
                 if ($reflection->isInstantiable() && $reflection->implementsInterface(CategoryInterface::class)) {


### PR DESCRIPTION
First of all, I would like to thank for creating such a useful and well-structured package. It has been a great foundation to build upon.
### Summary
This pull request addresses an issue in the `CategoryDiscovery` component related to resolving class namespaces when the path to the classes is changed in the project configuration.
### Problem
Previously, `CategoryDiscovery` allowed changing the path to locate the target classes via configuration. However, when the path was changed, the system still attempted to resolve the classes using a static namespace defined internally. Because the physical location of the class files and their declared namespaces no longer matched the static namespace, this caused resolution errors and failures in locating the classes correctly.
### What was changed
In this update, instead of relying on a fixed static namespace, the code now opens the moved file and reads the actual namespace declared inside the class file. It then uses this real namespace to register and resolve the class within the system.
This approach ensures that even if the files are moved to a new location with a different namespace, the class resolution works correctly without errors.
### Benefits
	•	Fixes class resolution errors caused by namespace mismatches after changing class file paths.
	•	Makes `CategoryDiscovery` more flexible and robust in handling dynamic project structures.
	•	Improves maintainability by relying on the actual namespace declarations rather than hardcoded assumptions.